### PR TITLE
Duplicate fixes 2

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -42,7 +42,7 @@ function fetchFolderContents() {
 // Function to find duplicates in a column and combine them in to one including the links
 function fixDuplicates() {
   // Variables to select active sheet, its range, and data.
-  var sheet = SpreadsheetApp.getActiveSheet();
+  var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Script");
   var lastRow = sheet.getLastRow();
   var dataRange = sheet.getRange(2, 1, lastRow - 1, 2);
   var data = dataRange.getValues();
@@ -61,7 +61,7 @@ function fixDuplicates() {
     }
     // If there is a duplicate, add links
     else {
-      linksByVin[currentVin] += currentUrl;
+      linksByVin[currentVin] += ', ' + currentUrl;
     }
 
     // Prepare for output
@@ -72,11 +72,11 @@ function fixDuplicates() {
     // Clears old data
     dataRange.clearContent();
 
-    console.log(linksByVin);
-
     // Write data
     var newDataRange = sheet.getRange(2, 1, outputData.length, 2);
     newDataRange.setValues(outputData);
-    // Test
+
+    var rangeFix = sheet.getRange("B2:B" + lastRow);
+    rangeFix.splitTextToColumns(", ");
   }
 };

--- a/src/Code.js
+++ b/src/Code.js
@@ -35,7 +35,6 @@ function fetchFolderContents() {
     //sheet.appendRow([nameFixed, link]);
     sheet.getRange(row, 1, 1, fileLink.length).setValues([fileLink]);
     row++;
-    console.log("Array:",fileLink);
   }
 };
 
@@ -76,6 +75,7 @@ function fixDuplicates() {
     var newDataRange = sheet.getRange(2, 1, outputData.length, 2);
     newDataRange.setValues(outputData);
 
+    // Splits the outputted URLs into separate columns by looking at the ", ".
     var rangeFix = sheet.getRange("B2:B" + lastRow);
     rangeFix.splitTextToColumns(", ");
   }


### PR DESCRIPTION
@InsaneBlitz
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] I have conducted thorough tests
- [x] Docs have been added / updated


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This request updates the fixDuplicates() function to split the outputted URLs into multiple columns. This fixes the last issue with this script.

* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/InsaneBlitz/Google-Drive-File-Names-Extract/issues/8

* **What is the new behavior (if this is a feature change)?**
The URLs are now split into different cells and columns as intended. Thus, allowing the formula embedded in the sheets to convert the URLs into thumbnails that Looker Studio can display.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None.

* **Other information**:
